### PR TITLE
#11 - Filter works in the first page only

### DIFF
--- a/django_admin_search/templates/admin/custom_search_form.html
+++ b/django_admin_search/templates/admin/custom_search_form.html
@@ -140,9 +140,10 @@
 
             /* 
                 
-                after changing the field, need to come back to first page
-                because the data is changed, the page length may also have
-                changed but if your need to keep a page, uncomment this
+                after apply filter is more common to leave user to the first page
+                because a data length is changed, current page may no longer exist 
+                (Ex, filter return empty queryset, nos has second page).
+                but if your need to keep a page, uncomment this
 
                 if (page != 0) { // this main current page
                     // params = 'p=' + page + '&' + params;

--- a/django_admin_search/templates/admin/custom_search_form.html
+++ b/django_admin_search/templates/admin/custom_search_form.html
@@ -135,10 +135,20 @@
             $('#advanced_admin_search input').each(function(k, v) {
                 v.disabled = v.value === '';
             });
-            params = $('#advanced_admin_search').serialize() 
-            if (page != 0) {
-                params = 'p=' + page + '&';
-            }
+            
+            params = $('#advanced_admin_search').serialize()
+
+            /* 
+                
+                after changing the field, need to come back to first page
+                because the data is changed, the page length may also have
+                changed but if your need to keep a page, uncomment this
+
+                if (page != 0) { // this main current page
+                    // params = 'p=' + page + '&' + params;
+                }
+            */
+            
             href = window.location.pathname
             window.location.href = href + '?' + params;
             return false;


### PR DESCRIPTION
In the current code, after apply de filter has a function to keep current page
but after apply the filters is more common to leave user to the first page, because a data length is changed, current page may no longer exist (Ex, filter return empty queryset, nos has second page).

for this reasson i commend this code 
```
if (page != 0) { // this main current page
    // params = 'p=' + page + '&' + params;
}
```